### PR TITLE
Fix flick in lazyRepeater and add new unit test

### DIFF
--- a/src/lazy-repeater-directive.js
+++ b/src/lazy-repeater-directive.js
@@ -41,30 +41,32 @@ angular.module('ngLazyRender').directive('lazyRepeater', [
                     var placeholder;
                     var placeholderEl;
                     var isolateScope;
+                    console.log()
+                    if (limit < bufferLength){
+                        placeholder = attrs.lazyPlaceholder ?
+                                $templateCache.get(attrs.lazyPlaceholder) || attrs.lazyPlaceholder : '';
+                        placeholderEl = angular.element('<div in-view="$inview && increaseLimit()">' + placeholder +
+                            '</div>');
 
-                    placeholder = attrs.lazyPlaceholder ?
-                            $templateCache.get(attrs.lazyPlaceholder) || attrs.lazyPlaceholder : '';
-                    placeholderEl = angular.element('<div in-view="$inview && increaseLimit()">' + placeholder +
-                        '</div>');
+                        isolateScope = $rootScope.$new();
+                        isolateScope.increaseLimit = function () {
+                            limit = Math.min(limit * 2, bufferLength);
 
-                    isolateScope = $rootScope.$new();
-                    isolateScope.increaseLimit = function () {
-                        limit = Math.min(limit * 2, bufferLength);
+                            if (limit === bufferLength) {
+                                $timeout(function () {
+                                    isolateScope.$destroy();
+                                    $animate.leave(placeholderEl);
+                                }, 0);
+                            }
+                        };
 
-                        if (limit === bufferLength) {
-                            $timeout(function () {
-                                isolateScope.$destroy();
-                                $animate.leave(placeholderEl);
-                            }, 0);
-                        }
-                    };
+                        $animate.enter(placeholderEl, el.parent(), el);
+                        $compile(placeholderEl)(isolateScope);
 
-                    $animate.enter(placeholderEl, el.parent(), el);
-                    $compile(placeholderEl)(isolateScope);
-
-                    $scope.getLazyLimit = function () {
-                        return limit;
-                    };
+                        $scope.getLazyLimit = function () {
+                            return limit;
+                        };
+                    }
                 };
             }
         };

--- a/tests/lazy-repeater-directive-spec.js
+++ b/tests/lazy-repeater-directive-spec.js
@@ -17,7 +17,7 @@ describe('lazyRepeater directive', function () {
     });
 
     it('should increase the number of shown elements of a repeater as we see the last one', function () {
-        $templateCache.put('templateUrl', '<placeholder></placeholder>')
+        $templateCache.put('templateUrl', '<placeholder></placeholder>');
 
         var initialScope = $rootScope.$new();
         initialScope.data = [];
@@ -30,7 +30,7 @@ describe('lazyRepeater directive', function () {
         }
 
         var el = $compile('<ul><li ng-repeat="obj in data track by obj.index" lazy-repeater="10" lazy-placeholder="templateUrl">{{obj.data}}</li></ul>')(initialScope);
-        $rootScope.$apply()
+        $rootScope.$apply();
 
         // After compiling the directive we should only see 10 elements
         expect(el.find('li').length).toBe(10);
@@ -56,4 +56,28 @@ describe('lazyRepeater directive', function () {
         $timeout.flush();
         expect(el.find('placeholder').length).toBe(0);
     });
+
+    it('should not render the placeholder when the object length is less then the lazy-repeater parameter', function () {
+        $templateCache.put('templateUrl', '<placeholder></placeholder>');
+
+        var initialScope = $rootScope.$new();
+        initialScope.data = [];
+
+        for (var i = 0; i < 8; i += 1) {
+            initialScope.data.push({
+                index: i,
+                data: 'such data'
+            });
+        }
+
+        var el = $compile('<ul><li ng-repeat="obj in data track by obj.index" lazy-repeater="10" lazy-placeholder="templateUrl">{{obj.data}}</li></ul>')(initialScope);
+        $rootScope.$apply();
+
+        // After compiling the directive we should see all the 8 elements
+        expect(el.find('li').length).toBe(8);
+        // The placeholder doesn't exist
+        expect(el.find('placeholder').length).toBe(0);
+        
+    });
+
 })


### PR DESCRIPTION
This code will fix the placeholder flick when the repeater length is less then the lazy-repeater parameter
