### PR TITLE
Fix flick in lazyRepeater and add new unit test

### DIFF
--- a/dist/ng-lazy-render.js
+++ b/dist/ng-lazy-render.js
@@ -2,6 +2,21 @@
  * Module declaration
  */
 angular.module('ngLazyRender', ['angular-inview']);
+/**
+ * Use this directive as an attribute if you want to delay the rendering of a module until visible
+ * in the viewport.
+ * 
+ * Attributes:
+ * - lazyModule: templateUrl of a placeholder to render while the module is not visible or while being
+ *               rendered.
+ * - lazyIf: use an angular expression here to set a condition on whether you want this directive to
+ *           take action or be ignored.
+ *
+ * Example:
+ * <my-module lazy-module="myModulePlaceholder.html" lazy-if="ctrl.acceleratePageLoad">
+ *  <!-- lots of code -->
+ * </my-module>
+ */
 angular.module('ngLazyRender').directive('lazyModule', [
     '$animate',
     '$compile',
@@ -14,10 +29,12 @@ angular.module('ngLazyRender').directive('lazyModule', [
         'use strict';
 
         return {
+            // 500 because is less than ngIf and ngRepeat
             priority: 500,
             terminal: true,
             transclude: 'element',
             link: function ($scope, $element, $attr, ctrl, $transclude) {
+                // If the expression in lazyIf is false, skip the directive's action
                 if ($parse($attr.lazyIf)($scope) === false) {
                     $transclude(function (clone) {
                         $animate.enter(clone, $element.parent(), $element);
@@ -28,30 +45,51 @@ angular.module('ngLazyRender').directive('lazyModule', [
                 var el = angular.element($templateCache.get($attr.lazyModule));
                 var isolateScope = $rootScope.$new();
 
-                isolateScope.update = function (inView) {
-                    if (inView) {
-                        isolateScope.$destroy();
-                        isolateScope = null;
+                // Callback for inViewDirective to be called when the module becomes visible.
+                // This will destroy the scope of the placeholder with inView and replace it with
+                // the actual transcluded content.
+                isolateScope.update = function () {
+                    // It is important to destroy the old scope or we'll get unwanted calls from
+                    // the inView directive.
+                    isolateScope.$destroy();
+                    isolateScope = null;
 
-                        $transclude(function (clone) {
-                            $animate.enter(clone, $element.parent(), $element);
-                            $animate.leave(el);
-                            el = null;
-                        });
-                    }
+                    $transclude(function (clone) {
+                        $animate.enter(clone, $element.parent(), $element);
+                        $animate.leave(el);
+                        el = null;
+                    });
                 };
 
                 $animate.enter(el, $element.parent(), $element);
                 $compile(el)(isolateScope);
 
+                // The number 100 here is a bit magic. We need to give the app some time to expand
+                // other directives in the page before we detect if our module is in the viewport.
+                // Postponing this to the next digest cycle should be enough but for some reason
+                // it's not enough on some slower environments. 100ms seems to be enough.
+                //
+                // TODO: investigate why this happens
                 $timeout(function () {
                     inViewDirective[0].compile()(isolateScope, el, {
-                        inView: "update($inview)"
+                        inView: "$inview && update()"
                     });
                 }, 100);
             }
         };
     }]);
+/**
+ * Use this directive as an attribute if you want a repeater (ng-repeat) to grow as the user scrolls down.
+ * 
+ * Attributes:
+ * - lazyRepeater: number of initially shown items. This number is doubled every time the user sees the end of the list.
+ * - lazyTemplate: template (or templateUrl) to be shown at the end of the list.
+ *
+ * Example:
+ * <my-module lazy-module="myModulePlaceholder.html" lazy-if="ctrl.acceleratePageLoad">
+ *  <!-- lots of code -->
+ * </my-module>
+ */
 angular.module('ngLazyRender').directive('lazyRepeater', [
     '$animate',
     '$compile',
@@ -83,30 +121,31 @@ angular.module('ngLazyRender').directive('lazyRepeater', [
                     var placeholder;
                     var placeholderEl;
                     var isolateScope;
+                    if (limit < bufferLength) {
+                        placeholder = attrs.lazyPlaceholder ?
+                                $templateCache.get(attrs.lazyPlaceholder) || attrs.lazyPlaceholder : '';
+                        placeholderEl = angular.element('<div in-view="$inview && increaseLimit()">' + placeholder +
+                            '</div>');
 
-                    placeholder = attrs.lazyPlaceholder ?
-                            $templateCache.get(attrs.lazyPlaceholder) || attrs.lazyPlaceholder : '';
-                    placeholderEl = angular.element('<div in-view="$inview && increaseLimit()">' + placeholder +
-                        '</div>');
+                        isolateScope = $rootScope.$new();
+                        isolateScope.increaseLimit = function () {
+                            limit = Math.min(limit * 2, bufferLength);
 
-                    isolateScope = $rootScope.$new();
-                    isolateScope.increaseLimit = function () {
-                        limit = Math.min(limit * 2, bufferLength);
+                            if (limit === bufferLength) {
+                                $timeout(function () {
+                                    isolateScope.$destroy();
+                                    $animate.leave(placeholderEl);
+                                }, 0);
+                            }
+                        };
 
-                        if (limit === bufferLength) {
-                            $timeout(function () {
-                                isolateScope.$destroy();
-                                $animate.leave(placeholderEl);
-                            }, 0);
-                        }
-                    };
+                        $animate.enter(placeholderEl, el.parent(), el);
+                        $compile(placeholderEl)(isolateScope);
 
-                    $animate.enter(placeholderEl, el.parent(), el);
-                    $compile(placeholderEl)(isolateScope);
-
-                    $scope.getLazyLimit = function () {
-                        return limit;
-                    };
+                        $scope.getLazyLimit = function () {
+                            return limit;
+                        };
+                    }
                 };
             }
         };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng-lazy-render",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "",
   "contributors": ["Andre Duarte <onemanclapping@gmail.com>", "Joao Pereira <joaomlap@gmail.com>"],
   "main": "./dist/ng-lazy-render.js",

--- a/src/lazy-repeater-directive.js
+++ b/src/lazy-repeater-directive.js
@@ -41,30 +41,32 @@ angular.module('ngLazyRender').directive('lazyRepeater', [
                     var placeholder;
                     var placeholderEl;
                     var isolateScope;
+                    console.log()
+                    if (limit < bufferLength){
+                        placeholder = attrs.lazyPlaceholder ?
+                                $templateCache.get(attrs.lazyPlaceholder) || attrs.lazyPlaceholder : '';
+                        placeholderEl = angular.element('<div in-view="$inview && increaseLimit()">' + placeholder +
+                            '</div>');
 
-                    placeholder = attrs.lazyPlaceholder ?
-                            $templateCache.get(attrs.lazyPlaceholder) || attrs.lazyPlaceholder : '';
-                    placeholderEl = angular.element('<div in-view="$inview && increaseLimit()">' + placeholder +
-                        '</div>');
+                        isolateScope = $rootScope.$new();
+                        isolateScope.increaseLimit = function () {
+                            limit = Math.min(limit * 2, bufferLength);
 
-                    isolateScope = $rootScope.$new();
-                    isolateScope.increaseLimit = function () {
-                        limit = Math.min(limit * 2, bufferLength);
+                            if (limit === bufferLength) {
+                                $timeout(function () {
+                                    isolateScope.$destroy();
+                                    $animate.leave(placeholderEl);
+                                }, 0);
+                            }
+                        };
 
-                        if (limit === bufferLength) {
-                            $timeout(function () {
-                                isolateScope.$destroy();
-                                $animate.leave(placeholderEl);
-                            }, 0);
-                        }
-                    };
+                        $animate.enter(placeholderEl, el.parent(), el);
+                        $compile(placeholderEl)(isolateScope);
 
-                    $animate.enter(placeholderEl, el.parent(), el);
-                    $compile(placeholderEl)(isolateScope);
-
-                    $scope.getLazyLimit = function () {
-                        return limit;
-                    };
+                        $scope.getLazyLimit = function () {
+                            return limit;
+                        };
+                    }
                 };
             }
         };

--- a/src/lazy-repeater-directive.js
+++ b/src/lazy-repeater-directive.js
@@ -41,8 +41,7 @@ angular.module('ngLazyRender').directive('lazyRepeater', [
                     var placeholder;
                     var placeholderEl;
                     var isolateScope;
-                    console.log()
-                    if (limit < bufferLength){
+                    if (limit < bufferLength) {
                         placeholder = attrs.lazyPlaceholder ?
                                 $templateCache.get(attrs.lazyPlaceholder) || attrs.lazyPlaceholder : '';
                         placeholderEl = angular.element('<div in-view="$inview && increaseLimit()">' + placeholder +

--- a/tests/lazy-repeater-directive-spec.js
+++ b/tests/lazy-repeater-directive-spec.js
@@ -17,7 +17,7 @@ describe('lazyRepeater directive', function () {
     });
 
     it('should increase the number of shown elements of a repeater as we see the last one', function () {
-        $templateCache.put('templateUrl', '<placeholder></placeholder>')
+        $templateCache.put('templateUrl', '<placeholder></placeholder>');
 
         var initialScope = $rootScope.$new();
         initialScope.data = [];
@@ -30,7 +30,7 @@ describe('lazyRepeater directive', function () {
         }
 
         var el = $compile('<ul><li ng-repeat="obj in data track by obj.index" lazy-repeater="10" lazy-placeholder="templateUrl">{{obj.data}}</li></ul>')(initialScope);
-        $rootScope.$apply()
+        $rootScope.$apply();
 
         // After compiling the directive we should only see 10 elements
         expect(el.find('li').length).toBe(10);
@@ -56,4 +56,28 @@ describe('lazyRepeater directive', function () {
         $timeout.flush();
         expect(el.find('placeholder').length).toBe(0);
     });
+
+    it('should not render the placeholder when the object length is less then the lazy-repeater parameter', function () {
+        $templateCache.put('templateUrl', '<placeholder></placeholder>');
+
+        var initialScope = $rootScope.$new();
+        initialScope.data = [];
+
+        for (var i = 0; i < 8; i += 1) {
+            initialScope.data.push({
+                index: i,
+                data: 'such data'
+            });
+        }
+
+        var el = $compile('<ul><li ng-repeat="obj in data track by obj.index" lazy-repeater="10" lazy-placeholder="templateUrl">{{obj.data}}</li></ul>')(initialScope);
+        $rootScope.$apply();
+
+        // After compiling the directive we should see all the 8 elements
+        expect(el.find('li').length).toBe(8);
+        // The placeholder doesn't exist
+        expect(el.find('placeholder').length).toBe(0);
+        
+    });
+
 })


### PR DESCRIPTION
This code will fix the placeholder flick when the repeater length is less then the lazy-repeater parameter
