### PR TITLE
lazy-module performance improvements

### DIFF
--- a/dist/ng-lazy-render.js
+++ b/dist/ng-lazy-render.js
@@ -43,13 +43,13 @@ angular.module('ngLazyRender').directive('lazyModule', ['$animate', '$compile', 
             // This will destroy the scope of the placeholder and replace it with
             // the actual transcluded content.
             isolateScope.showModule = function () {
-                // If the function is called after the scope is destroyed (more than once),
-                // we should do nothing.
-                if (isolateScope === null) {
-                    return;
-                }
-
                 $scope.$applyAsync(function () {
+                    // If the function is called after the scope is destroyed (more than once),
+                    // we should do nothing.
+                    if (isolateScope === null) {
+                        return;
+                    }
+
                     // It is important to destroy the old scope or we'll never kill VisibilityService
                     isolateScope.$destroy();
                     isolateScope = null;

--- a/dist/ng-lazy-render.js
+++ b/dist/ng-lazy-render.js
@@ -49,7 +49,7 @@ angular.module('ngLazyRender').directive('lazyModule', ['$animate', '$compile', 
                     return;
                 }
 
-                $scope.$apply(function () {
+                $scope.$applyAsync(function () {
                     // It is important to destroy the old scope or we'll never kill VisibilityService
                     isolateScope.$destroy();
                     isolateScope = null;
@@ -216,8 +216,8 @@ angular.module('ngLazyRender').provider('VisibilityService', [function () {
         }
 
         function _startWatching() {
-            if (!intervalPromise) {
-                intervalPromise = $interval(this._checkInView, delay, 0, false);
+            if (!intervalPromise && delay) {
+                intervalPromise = $interval(this.checkInView, delay, 0, false);
             }
         }
 
@@ -229,7 +229,7 @@ angular.module('ngLazyRender').provider('VisibilityService', [function () {
         }
 
         // Code partially stolen from angular-inview. Thanks thenikso!
-        function _checkInView() {
+        function checkInView() {
             var viewport = {
                 top: 0,
                 bottom: getViewportHeight()
@@ -277,7 +277,7 @@ angular.module('ngLazyRender').provider('VisibilityService', [function () {
         return {
             _startWatching: _startWatching,
             _stopWatching: _stopWatching,
-            _checkInView: _checkInView,
+            checkInView: checkInView,
             whenVisible: whenVisible
         };
     }];

--- a/src/lazy-module-directive.js
+++ b/src/lazy-module-directive.js
@@ -44,13 +44,13 @@ angular.module(`ngLazyRender`).directive(`lazyModule`, [
                 // This will destroy the scope of the placeholder and replace it with
                 // the actual transcluded content.
                 isolateScope.showModule = function () {
-                    // If the function is called after the scope is destroyed (more than once),
-                    // we should do nothing.
-                    if (isolateScope === null) {
-                        return
-                    }
-
                     $scope.$applyAsync(() => {
+                        // If the function is called after the scope is destroyed (more than once),
+                        // we should do nothing.
+                        if (isolateScope === null) {
+                            return
+                        }
+
                         // It is important to destroy the old scope or we'll never kill VisibilityService
                         isolateScope.$destroy()
                         isolateScope = null

--- a/src/lazy-module-directive.js
+++ b/src/lazy-module-directive.js
@@ -50,7 +50,7 @@ angular.module(`ngLazyRender`).directive(`lazyModule`, [
                         return
                     }
 
-                    $scope.$apply(() => {
+                    $scope.$applyAsync(() => {
                         // It is important to destroy the old scope or we'll never kill VisibilityService
                         isolateScope.$destroy()
                         isolateScope = null

--- a/src/visibility-service.js
+++ b/src/visibility-service.js
@@ -2,7 +2,7 @@ angular.module(`ngLazyRender`).provider(`VisibilityService`, [function () {
   let delay = 500
 
   this.setDelay = function (newDelay) {
-    delay = newDelay
+    delay = newDelay;
   }
 
   this.$get = [`$interval`, `$q`, function ($interval, $q) {
@@ -50,8 +50,8 @@ angular.module(`ngLazyRender`).provider(`VisibilityService`, [function () {
     }
 
     function _startWatching() {
-      if (!intervalPromise) {
-        intervalPromise = $interval(this._checkInView, delay, 0, false)
+      if (!intervalPromise && delay) {
+        intervalPromise = $interval(this.checkInView, delay, 0, false)
       }
     }
 
@@ -63,7 +63,7 @@ angular.module(`ngLazyRender`).provider(`VisibilityService`, [function () {
     }
 
     // Code partially stolen from angular-inview. Thanks thenikso!
-    function _checkInView() {
+    function checkInView() {
       const viewport = {
         top: 0,
         bottom: getViewportHeight()
@@ -107,7 +107,7 @@ angular.module(`ngLazyRender`).provider(`VisibilityService`, [function () {
     return {
       _startWatching,
       _stopWatching,
-      _checkInView,
+      checkInView,
       whenVisible
     }
   }]

--- a/tests/lazy-module-directive-spec.js
+++ b/tests/lazy-module-directive-spec.js
@@ -48,6 +48,7 @@ describe(`lazyModule directive`, () => {
         // When the placeholder becomes visible, its update function is called.
         // Let us pretend it happened!
         lazyScope.showModule()
+        $rootScope.$digest()
 
         // Now the placeholder should not be visible anymore
         expect(el.find(`placeholder`).length).toBe(0)

--- a/tests/visibility-service-spec.js
+++ b/tests/visibility-service-spec.js
@@ -2,12 +2,13 @@ describe('VisibilityService', () => {
 	const $intervalMock = jasmine.createSpy('$interval').and.returnValue({})
 	$intervalMock.cancel = jasmine.createSpy('$intervalCancel').and.stub()
 
-	let $rootScope, VisibilityService
+	let $rootScope, VisibilityService, VisibilityServiceProvider
 
 	beforeEach(() => {
 		module('ngLazyRender')
-		module(['$provide', 'VisibilityServiceProvider', ($provide, VisibilityServiceProvider) => {
+		module(['$provide', 'VisibilityServiceProvider', ($provide, _VisibilityServiceProvider_) => {
 			$provide.value('$interval', $intervalMock)
+			VisibilityServiceProvider = _VisibilityServiceProvider_
 			VisibilityServiceProvider.setDelay(450)
 		}])
 
@@ -28,6 +29,20 @@ describe('VisibilityService', () => {
 			expect($intervalMock.calls.argsFor(0)[1]).toBe(450)
 			VisibilityService._startWatching()
 			expect($intervalMock.calls.count()).toBe(1)
+		})
+
+		describe('if delay is disabled', () => {
+			beforeEach(() => {
+				$intervalMock.calls.reset()
+				VisibilityServiceProvider.setDelay(false)
+				inject();
+			})
+
+			it('should not call $interval', () => {
+				expect($intervalMock).not.toHaveBeenCalled()
+				VisibilityService._startWatching()
+				expect($intervalMock).not.toHaveBeenCalled()
+			})
 		})
 	})
 


### PR DESCRIPTION
With this merge request I add the possibility to control when to call the checkInView callback (e.g. onscroll events)

Also swapped `$apply` for `$applyAsync` in order to improve performance when using multiple `lazy-module` directives on the same page (it will trigger only one digest).

I tried to avoid any breaking changes (but could be missing something)