### PR TITLE
lazy-hide parameter to the lazy-module directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.2.0
+### Features
+lazy-hide parameter on lazy-module directive
+
 # 1.1.3
 ### Bug Fixes
 lazy-module directive was not working.

--- a/README.md
+++ b/README.md
@@ -11,10 +11,18 @@ Attributes:
 
 - lazyIf: use an angular expression here to set a condition on whether you want this directive to take action or be ignored.
 
-Example:
+- lazyHide: (optional) an angular expression to only hide the placeholder. With this parameter, this directive ignores the visibility of the module and only hides the placeholder when told to
+
+Examples:
 
 ```html
 <any lazy-module="myModulePlaceholder.html" lazy-if="ctrl.acceleratePageLoad">
+    <!-- lots of code -->
+</any>
+```
+
+```html
+<any lazy-module="myModulePlaceholder.html" lazy-if="ctrl.acceleratePageLoad" lazy-hide="ctrl.hidePlaceholder">
     <!-- lots of code -->
 </any>
 ```

--- a/dist/ng-lazy-render.js
+++ b/dist/ng-lazy-render.js
@@ -22,6 +22,31 @@ angular.module('ngLazyRender', []);
 angular.module('ngLazyRender').directive('lazyModule', ['$animate', '$compile', '$parse', '$q', '$templateCache', 'VisibilityService', function ($animate, $compile, $parse, $q, $templateCache, VisibilityService) {
     'use strict';
 
+    var hidePlaceholder = function hidePlaceholder($transclude, scope, placeholderElem, moduleElem, finallyCb) {
+        // If the function is called after the scope is destroyed (more than once),
+        // we should do nothing.
+        if (scope === null) {
+            return;
+        }
+
+        // It is important to destroy the old scope or we'll never kill VisibilityService
+        scope.$destroy();
+        scope = null;
+
+        $transclude(function (clone) {
+            var enterPromise = $animate.enter(clone, moduleElem.parent(), moduleElem);
+            var leavePromise = $animate.leave(placeholderElem);
+
+            var promise = $q.all([enterPromise, leavePromise]).then(function () {
+                placeholderElem = null;
+            });
+
+            if (finallyCb) {
+                promise.finally(finallyCb);
+            }
+        });
+    };
+
     return {
         // 500 because is less than ngIf and ngRepeat
         priority: 500,
@@ -38,37 +63,29 @@ angular.module('ngLazyRender').directive('lazyModule', ['$animate', '$compile', 
 
             var el = angular.element($templateCache.get($attr.lazyModule));
             var isolateScope = $scope.$new(true);
+            var watcher = void 0;
 
-            // Callback for VisibilityService to be called when the module becomes visible.
-            // This will destroy the scope of the placeholder and replace it with
-            // the actual transcluded content.
-            isolateScope.showModule = function () {
-                $scope.$applyAsync(function () {
-                    // If the function is called after the scope is destroyed (more than once),
-                    // we should do nothing.
-                    if (isolateScope === null) {
-                        return;
+            if ($attr.lazyHide) {
+                watcher = $scope.$watch($attr.lazyHide, function (value) {
+                    if (!!value) {
+                        hidePlaceholder($transclude, isolateScope, el, $element, watcher);
                     }
-
-                    // It is important to destroy the old scope or we'll never kill VisibilityService
-                    isolateScope.$destroy();
-                    isolateScope = null;
-
-                    $transclude(function (clone) {
-                        var enterPromise = $animate.enter(clone, $element.parent(), $element);
-                        var leavePromise = $animate.leave(el);
-
-                        $q.all([enterPromise, leavePromise]).then(function () {
-                            el = null;
-                        });
-                    });
                 });
-            };
+            } else {
+                // Callback for VisibilityService to be called when the module becomes visible.
+                // This will destroy the scope of the placeholder and replace it with
+                // the actual transcluded content.
+                isolateScope.showModule = function () {
+                    $scope.$applyAsync(function () {
+                        hidePlaceholder($transclude, isolateScope, el, $element);
+                    });
+                };
 
-            $animate.enter(el, $element.parent(), $element).then(function () {
-                $compile(el)(isolateScope);
-                VisibilityService.whenVisible(el, isolateScope, isolateScope.showModule);
-            });
+                $animate.enter(el, $element.parent(), $element).then(function () {
+                    $compile(el)(isolateScope);
+                    VisibilityService.whenVisible(el, isolateScope, isolateScope.showModule);
+                });
+            }
         }
     };
 }]);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng-lazy-render",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "A set of directives to postpone your angular application from rendering elements outside the viewport.",
   "contributors": ["Andre Duarte <onemanclapping@gmail.com>", "Joao Pereira <joaomlap@gmail.com>"],
   "main": "./dist/ng-lazy-render.js",

--- a/tests/lazy-module-directive-spec.js
+++ b/tests/lazy-module-directive-spec.js
@@ -66,4 +66,27 @@ describe(`lazyModule directive`, () => {
         // After compiling the directive we should no longer be able to see the content
         expect(el.find(`module`).length).not.toBe(0)
     })
+
+    it('should show the placeholder only when we tell it to', function () {
+        $templateCache.put('templateUrl', '<placeholder></placeholder>')
+        $rootScope.hidePlaceholder = false
+
+        var initialScope = $rootScope.$new()
+        var el = $compile('<div><module lazy-module="templateUrl" lazy-hide="hidePlaceholder"></module></div>')(initialScope)
+
+        // After compiling the directive we should no longer be able to see the content
+        expect(el.find('module').length).toBe(0)
+
+        // Also, we should now see the placeholder (article) and it should have its own scope
+        var lazyScope = el.find('placeholder').scope()
+        expect(lazyScope).not.toBe(initialScope)
+
+        $rootScope.hidePlaceholder = true
+        initialScope.$digest()
+        // Now the placeholder should not be visible anymore
+        expect(el.find('placeholder').length).toBe(0)
+
+        // And the module should be visible again
+        expect(el.find('module').length).not.toBe(0)
+    })
 })


### PR DESCRIPTION
Added lazy-hide parameter to the lazy-module directive.
This way, the placeholder only hides when we told it to, and ignores the visibility of the module.
It is useful when we want to synchronise placeholders of several modules, or when we have a module with content loaded through asynchronous requests.

@onemanclapping 